### PR TITLE
Add logout controls and fix login flow

### DIFF
--- a/client/src/pages/EmployeePage.tsx
+++ b/client/src/pages/EmployeePage.tsx
@@ -1,10 +1,15 @@
 // src/EmployeePage.tsx
 import React from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
 import { PageShell } from "../components/hr/Shared";
 import EmployeeLeavePage from "./EmployeeLeavePage";
 import WorkLogFormMini from "./WorkLogFormMini";
 
 export default function EmployeePage() {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+  const handleLogout = () => { logout(); navigate("/login"); };
   const [tab, setTab] = React.useState<"leave" | "worklog">("leave");
 
   return (
@@ -16,6 +21,7 @@ export default function EmployeePage() {
       ]}
       activeTab={tab}
       onChangeTab={(k)=>setTab(k as any)}
+      right={<button className="btn-ghost" onClick={handleLogout}>로그아웃</button>}
     >
       {tab === "leave"   && <EmployeeLeavePage />}
       {tab === "worklog" && <WorkLogFormMini />}

--- a/client/src/pages/HRAdminPage.tsx
+++ b/client/src/pages/HRAdminPage.tsx
@@ -1,7 +1,9 @@
 // src/pages/HRAdminPage.tsx
 import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import ExcelJS from "exceljs";
 import { saveAs } from "file-saver";
+import { useAuth } from "../auth/AuthContext";
 import {
   API_BASE, STATUS_KO, Status, LeaveRequestAPI, WorklogRow,
   dataUrlToUint8, fmtReqDate, fmtStart, fmtEnd,
@@ -10,6 +12,9 @@ import {
 
 export default function HRAdminPage() {
   injectCleanTheme();
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+  const handleLogout = () => { logout(); navigate("/login"); };
 
   const [activeTab, setActiveTab] = useState<"leave"|"worklog">("leave");
 
@@ -195,11 +200,14 @@ export default function HRAdminPage() {
     <div className="page-wrap mgr">
       <div className="shell">
         <div className="header">
-          <div className="title">인사 관리자</div>
-          <div className="tabs">
-            <button className="tab" aria-pressed={activeTab==="leave"} onClick={()=>setActiveTab("leave")}>연차관리</button>
-            <button className="tab" aria-pressed={activeTab==="worklog"} onClick={()=>setActiveTab("worklog")}>근무일지</button>
+          <div style={{ display:"flex", gap:8, alignItems:"center" }}>
+            <div className="title">인사 관리자</div>
+            <div className="tabs">
+              <button className="tab" aria-pressed={activeTab==="leave"} onClick={()=>setActiveTab("leave")}>연차관리</button>
+              <button className="tab" aria-pressed={activeTab==="worklog"} onClick={()=>setActiveTab("worklog")}>근무일지</button>
+            </div>
           </div>
+          <button className="btn-ghost" onClick={handleLogout}>로그아웃</button>
         </div>
 
         {activeTab==="leave" ? (

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,9 +1,13 @@
 // src/pages/LoginPage.tsx
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { API_BASE, jsonFetch, injectCleanTheme } from "../components/hr/Shared";
+import { useAuth } from "../auth/AuthContext";
 
-export default function LoginPage({ onLoggedIn }: { onLoggedIn: (role: string) => void }) {
+export default function LoginPage() {
   injectCleanTheme();
+  const { login } = useAuth();
+  const navigate = useNavigate();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
@@ -24,9 +28,10 @@ export default function LoginPage({ onLoggedIn }: { onLoggedIn: (role: string) =
       }
       const j = data as any; // { ok:true, token, role }
       if (!j?.ok || !j?.token) throw new Error((j && j.error) || "로그인 실패");
-      localStorage.setItem("lm_token", j.token);
-      localStorage.setItem("lm_role", j.role || "employee");
-      onLoggedIn(j.role || "employee");
+      login(j.token);
+      const role = j.role || "employee";
+      localStorage.setItem("lm_role", role);
+      navigate(role === "manager" ? "/manager" : role === "hr" ? "/hr" : role === "admin" ? "/hr" : "/employee");
     } catch (e: any) {
       setErr(e?.message || "로그인 실패");
     } finally {

--- a/client/src/pages/ManagerPage.tsx
+++ b/client/src/pages/ManagerPage.tsx
@@ -1,5 +1,7 @@
 // src/pages/ManagerPage.tsx
 import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
 import {
   API_BASE, Status, STATUS_KO, LeaveRequestAPI, WorklogRow,
   jsonFetch, injectCleanTheme, StatusBadge, SignaturePad
@@ -7,6 +9,9 @@ import {
 
 export default function ManagerPage() {
   injectCleanTheme();
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+  const handleLogout = () => { logout(); navigate("/login"); };
 
   const [tab, setTab] = useState<"requests"|"worklogs">("requests");
 
@@ -140,11 +145,14 @@ export default function ManagerPage() {
     <div className="page-wrap mgr">
       <div className="shell">
         <div className="header">
-          <div className="title">상사 검토</div>
-          <div className="tabs">
-            <button className="tab" onClick={()=>setTab("requests")} aria-pressed={tab==="requests"}>연차 신청</button>
-            <button className="tab" onClick={()=>setTab("worklogs")} aria-pressed={tab==="worklogs"}>근무일지</button>
+          <div style={{ display:"flex", gap:8, alignItems:"center" }}>
+            <div className="title">상사 검토</div>
+            <div className="tabs">
+              <button className="tab" onClick={()=>setTab("requests")} aria-pressed={tab==="requests"}>연차 신청</button>
+              <button className="tab" onClick={()=>setTab("worklogs")} aria-pressed={tab==="worklogs"}>근무일지</button>
+            </div>
           </div>
+          <button className="btn-ghost" onClick={handleLogout}>로그아웃</button>
         </div>
 
         {tab==="requests" && (


### PR DESCRIPTION
## Summary
- handle login with auth context and role-based navigation
- add logout buttons to employee, manager, and HR admin pages

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm run lint` (server) *(fails: Missing script "lint")*
- `npm run build` (server)
- `npm test` (client) *(fails: Missing script "test")*
- `npm run lint` (client) *(fails: Missing script "lint")*
- `npm run build` (client)
- `curl -i -X POST http://localhost:4000/api/login -H 'Content-Type: application/json' -d '{"username":"admin","password":"admin123!"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b18a24dd188326ba591195c923baaf