### PR TITLE
Improve login form validation

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -48,9 +48,27 @@ export default function LoginPage() {
             <div className="title" style={{textAlign:"center"}}>로그인</div>
             <form onSubmit={doLogin}>
               <div style={{display:"grid", gap:10}}>
-                <input className="inp" placeholder="아이디" value={username} onChange={e=>setUsername(e.target.value)} />
-                <input className="inp" placeholder="비밀번호" type="password" value={password} onChange={e=>setPassword(e.target.value)} />
-                <button className="btn btn-primary" disabled={busy}>{busy ? "로그인 중…" : "로그인"}</button>
+                <input
+                  className="inp"
+                  placeholder="아이디"
+                  value={username}
+                  onChange={e=>setUsername(e.target.value)}
+                  required
+                />
+                <input
+                  className="inp"
+                  placeholder="비밀번호"
+                  type="password"
+                  value={password}
+                  onChange={e=>setPassword(e.target.value)}
+                  required
+                />
+                <button
+                  className="btn btn-primary"
+                  disabled={busy || !username || !password}
+                >
+                  {busy ? "로그인 중…" : "로그인"}
+                </button>
                 {err && <div className="badge" style={{borderColor:"#fecaca", color:"#b91c1c"}}>오류: {err}</div>}
               </div>
             </form>


### PR DESCRIPTION
## Summary
- require username and password fields in login form
- disable login button until both credentials are provided

## Testing
- `curl -s -X POST http://localhost:4000/api/login -H 'Content-Type: application/json' -d '{"username":"admin","password":"admin123!"}'`
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")
- `npm --prefix client test` (fails: Missing script "test")
- `npm --prefix client run lint` (fails: Missing script "lint")
- `npm --prefix server test` (fails: Missing script "test")
- `npm --prefix server run lint` (fails: Missing script "lint")

------
https://chatgpt.com/codex/tasks/task_e_68b5934d24b08326b5b38ce0c5753d6f